### PR TITLE
hyväksymistestejä aloitettu cucumberilla

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,15 @@ repositories {
     jcenter()
 }
 
+project.ext {
+    cucumberVersion = '6.8.1';
+}
+
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13'
     testCompile 'org.mockito:mockito-core:3.1.0'
+    testCompile 'io.cucumber:cucumber-java:' + cucumberVersion;
+    testCompile 'io.cucumber:cucumber-junit:' + cucumberVersion;
 }
 
 jar {

--- a/src/test/java/cucumber/RunCucumberTest.java
+++ b/src/test/java/cucumber/RunCucumberTest.java
@@ -1,0 +1,16 @@
+package cucumber;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import io.cucumber.junit.CucumberOptions.SnippetType;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    plugin = "pretty",
+    features = "src/test/resources/",
+    snippets = SnippetType.CAMELCASE
+)
+
+public class RunCucumberTest {};
+

--- a/src/test/java/cucumber/Stepdefs.java
+++ b/src/test/java/cucumber/Stepdefs.java
@@ -1,0 +1,44 @@
+package cucumber;
+
+import dao.LukuvinkkiDao;
+import io.ConsoleIO;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import ui.ConsoleUI;
+
+public class Stepdefs {
+    
+    ConsoleIO mockIO;
+    LukuvinkkiDao mockLukuvinkkiDao;
+    
+    ConsoleUI ui;
+    
+    @Given("konsoli pyytaa lukuvinkin otsikkoa")
+    public void konsoliPyytaaOtsikkoa() {
+        
+    }
+    
+    @When("kelvollinen otsikko {string} syotetaan konsoliin")
+    public void kelvollinenOtsikkoSyotetaan(String otsikko) {
+        mockIO = mock(ConsoleIO.class);
+        mockLukuvinkkiDao = mock(LukuvinkkiDao.class);
+        
+        when(mockIO.readInput("Anna lukuvinkin otsikko: ")).thenReturn(otsikko);
+        
+        ui = new ConsoleUI(mockIO, mockLukuvinkkiDao);
+        
+        ui.run();
+        
+    }
+    
+    @Then("konsoli vastaa viestilla {string}")
+    public void konsoliVastaaViestilla(String viesti) {
+        verify(mockIO).printOutput(eq(viesti));
+    }
+    
+}

--- a/src/test/resources/classes/lisaa_lukuvinkki_otsikolla.feature
+++ b/src/test/resources/classes/lisaa_lukuvinkki_otsikolla.feature
@@ -1,0 +1,6 @@
+Feature: Kayttaja voi lisata lukuvinkin otsikolla
+
+    Scenario: kayttaja voi lisata lukuvinkin kelvollisella otsikolla
+        Given konsoli pyytaa lukuvinkin otsikkoa
+        When kelvollinen otsikko "Testiotsikko" syotetaan konsoliin
+        Then konsoli vastaa viestilla "Luotiin lukuvinkki: Testiotsikko"

--- a/src/test/resources/cucumber.properties
+++ b/src/test/resources/cucumber.properties
@@ -1,0 +1,1 @@
+cucumber.publish.quiet=true


### PR DESCRIPTION
Cucumberilla tehty yksi testi joka varmistaa, että kelvollisella otsikolla voi lisätä lukuvinkin (käytännössä testi testaa vain, että konsoli palauttaa tekstin "Luotiin lukuvinkki: [nimi]". Seuraavassa sprintissä voisi vielä toteuttaa sen että testi katsoo tiedostosta että vinkki varmasti lisättiin)