### PR TITLE
Vinkin poisto-ominaisuus toimii

### DIFF
--- a/src/main/java/dao/LukuvinkkiDao.java
+++ b/src/main/java/dao/LukuvinkkiDao.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 
 
 import domain.Lukuvinkki;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class LukuvinkkiDao {
 
@@ -23,19 +25,15 @@ public class LukuvinkkiDao {
     Scanner scanner;
     Boolean testFile = false;
 
-    public void saveToFile(Lukuvinkki content) throws IOException {
+    public void saveToFile(Lukuvinkki content) {
         
-        
-        newFile = new File(filePath + ".txt");
-        newFile.createNewFile();
-
-        if (testFile) {
-            newFile.deleteOnExit();
+        if (newFile == null) {
+            createFile();
         }
 
         if (readFromFile() == null) {
             vinkit = new ArrayList<Lukuvinkki>();
-            
+
             vinkit.add(content);
         }
 
@@ -46,69 +44,102 @@ public class LukuvinkkiDao {
             vinkit.add(content);
         }
 
-
         String output = gson.toJson(vinkit);
     
-        FileOutputStream oFile = new FileOutputStream(newFile, false); 
-        FileWriter fileWriter = new FileWriter(newFile);
-        fileWriter.write(output + "\n");
-        
-        fileWriter.close();
+        //FileOutputStream oFile = new FileOutputStream(newFile, false); 
+        writeToFile(output);
    
     }
-
-    public void saveListToFile(List<Lukuvinkki> content) throws IOException {
+    
+    public void deleteFromFile(Lukuvinkki content) {
         
+        vinkit = readFromFile();
+        
+        if (vinkit != null) {
+            vinkit.remove(content);
+            
+            String output = gson.toJson(vinkit);
+            writeToFile(output);
+        }
+        
+    }
+
+    public void saveListToFile(List<Lukuvinkki> content){
+        
+        if (newFile == null) {
+            createFile();
+        }
+        
+        String output = gson.toJson(content);
+    
+        //FileOutputStream oFile = new FileOutputStream(newFile, false); 
+        writeToFile(output);
+       
+    }
+
+    public List<Lukuvinkki> readFromFile() {
+        
+        String content = "";
+        
+        List<Lukuvinkki> fileContent = null;
+        
+        try {
+            
+            FileInputStream input = new FileInputStream(filePath + ".txt");
+            scanner = new Scanner(input);
+            
+            if (!scanner.hasNextLine()) {
+                return null;
+            }
+
+            while (scanner.hasNextLine()) {
+                String next = scanner.nextLine();
+                content = content + next;
+            }
+
+            scanner.close();
+
+            fileContent = gson.fromJson(content, new TypeToken<List<Lukuvinkki>>() {}.getType());
+
+            input.close();
+            
+        } catch (IOException e) {
+            System.out.println("VIRHE: " + e.getMessage());
+        }
+       
+        return fileContent;
+
+    }
+    
+    //apumetodi copypasten vähentämiseksi
+    public void createFile() {
         
         newFile = new File(filePath + ".txt");
-        newFile.createNewFile();
-
+        try {
+            newFile.createNewFile();
+        } catch (IOException e) {
+            System.out.println("VIRHE: " + e.getMessage());
+        }
+        
         if (testFile) {
             newFile.deleteOnExit();
         }
-
-        String output = gson.toJson(content);
-    
-        FileOutputStream oFile = new FileOutputStream(newFile, false); 
-        FileWriter fileWriter = new FileWriter(newFile);
-        fileWriter.write(output + "\n");
         
-        fileWriter.close();
-   
     }
-
-    public List<Lukuvinkki> readFromFile() throws FileNotFoundException, IOException {
+    
+    //apumetodi copypasten vähentämiseksi
+    public void writeToFile(String content) {
         
-       
-        String content = "";
-        
-
-        
-        FileInputStream input = new FileInputStream(filePath + ".txt");
-        scanner = new Scanner(input);
-       
-        
-        
-        
-        if (!scanner.hasNextLine()) {
-            return null;
+        FileWriter fileWriter;
+        try {
+            fileWriter = new FileWriter(newFile);
+            fileWriter.write(content + "\n");
+            fileWriter.flush();
+            fileWriter.close();
+        } catch (IOException e) {
+            System.out.println("VIRHE: " + e.getMessage());
         }
         
-        while (scanner.hasNextLine()) {
-            
-            content = content + scanner.nextLine();
-        }
-         
-        
-
-        scanner.close();
-
-        List<Lukuvinkki> fileContent = gson.fromJson(content, new TypeToken<List<Lukuvinkki>>() {}.getType());
-
-        
-        
-        return fileContent;
-
     }
 
     public void useTestFile() throws IOException, FileNotFoundException {

--- a/src/main/java/domain/Lukuvinkki.java
+++ b/src/main/java/domain/Lukuvinkki.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.lang.reflect.Type;
 import com.google.gson.InstanceCreator;
 import java.time.format.DateTimeFormatter;
+import java.util.Objects;
 
 public class Lukuvinkki implements InstanceCreator<Lukuvinkki> {
 
@@ -67,5 +68,30 @@ public class Lukuvinkki implements InstanceCreator<Lukuvinkki> {
     public String changeTimeToString(LocalDateTime time) {
         return this.addDateTime.format(DateTimeFormatter.ofPattern("dd.MM.yyyy hh:mm"));
     }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        final Lukuvinkki other = (Lukuvinkki) obj;
+        if (!Objects.equals(this.label, other.label)) {
+            return false;
+        }
+        if (!Objects.equals(this.type, other.type)) {
+            return false;
+        }
+        if (!Objects.equals(this.link, other.link)) {
+            return false;
+        }
+        if (!Objects.equals(this.addDateTime, other.addDateTime)) {
+            return false;
+        }
+        return true;
+    }
+    
+    
 
 }

--- a/src/main/java/ui/ConsoleUI.java
+++ b/src/main/java/ui/ConsoleUI.java
@@ -8,6 +8,8 @@ import io.ConsoleIO;
 import java.io.*;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class ConsoleUI {
 
@@ -15,7 +17,6 @@ public class ConsoleUI {
     private LukuvinkkiDao dao;
     private List<Lukuvinkki> vinkit;
     String syote;
-    private String linkki;
     
 
     public ConsoleUI(ConsoleIO console, LukuvinkkiDao dao) {
@@ -27,9 +28,11 @@ public class ConsoleUI {
     private void lueVinkit() throws IOException, FileNotFoundException {
         try {
             vinkit = dao.readFromFile();
+            if (vinkit == null) {
+                vinkit = new ArrayList<Lukuvinkki>();
+            }
         } catch (Exception e) {
             console.printOutput("VIRHE: " + e.getMessage());
-            vinkit = new ArrayList<Lukuvinkki>();
         }
     }
 
@@ -50,7 +53,7 @@ public class ConsoleUI {
                 i++;
                 console.printOutput(String.format("%2d  %-20.20s  %s", i, v.getLabel(), v.getAddTime()));
             }
-            console.printOutput("99 < Lopeta ohjelma >");
+            console.printOutput("999 < Lopeta ohjelma >");
 
             // Lue syöte. Teksti tarkoittaa hakua, numero jotain toimintoa
             syote = console.readInput("\nValitse vinkki numerolla tai kirjoita teksti hakua varten:");
@@ -76,10 +79,10 @@ public class ConsoleUI {
                 lueVinkit();
                 rajattu = false;
                 continue;
-            } else if (numero > 0 && numero <= vinkit.size() + 1) {
+            } else if (numero > 0 && numero <= vinkit.size()) {
                 nayta(vinkit.get(numero - 1), (numero - 1)); // Valinnat alkavat ykkösestä
                 continue;
-            } else if (numero == 99) { // Lopetus
+            } else if (numero == 999) { // Lopetus
                 break;
             }
         }
@@ -89,18 +92,28 @@ public class ConsoleUI {
         
         console.printOutput("\n" + v.toString());
         
-        linkki = console.readInput("\nMuokkaa vinkin linkkiä valitsemalla M, 0 palauttaa alkuvalikkoon");
-        if (linkki.equals("M")) {
+        String valinta = console.readInput("\nMuokkaa vinkin linkkiä valitsemalla M"
+                + "\nPoista linkki valitsemalla P"
+                + "\nPalaa alkuvalikkoon valitsemalla 0");
+        if (valinta.equals("M")) {
             v.setLink(console.readInput("\nKirjoita URL: "));
             // Muokattu vinkki paikataan listassa
             vinkit.set(i, v);
             dao.saveListToFile(vinkit);
-        } else if (linkki.equals("0")) {
+        } else if (valinta.equals("P")) {
+            poista(v);
+        } else if (valinta.equals("0")) {
             console.printOutput("\nPoistuttiin.");
         } else {
             console.printOutput("\nValintaa ei tunnistettu");
         }
         
+    }
+    
+    public void poista(Lukuvinkki v) {
+        dao.deleteFromFile(v);
+        vinkit = dao.readFromFile();
+        console.printOutput("Poistettiin: " + v.getLabel());
     }
 
     public void lisaa() {

--- a/src/test/java/cucumber/Stepdefs.java
+++ b/src/test/java/cucumber/Stepdefs.java
@@ -21,6 +21,9 @@ public class Stepdefs {
     LukuvinkkiDao mockLukuvinkkiDao;
     Kirja vinkki;
     ConsoleUI ui;
+    
+    String addNumber;
+    String exitNumber;
 
     @Given("konsoli pyytaa lukuvinkin otsikkoa")
     public void konsoliPyytaaOtsikkoa() {
@@ -28,6 +31,9 @@ public class Stepdefs {
         mockLukuvinkkiDao = mock(LukuvinkkiDao.class);
         vinkki = new Kirja("Testiotsikko");
         ui = new ConsoleUI(mockIO, mockLukuvinkkiDao);
+        
+        addNumber = "0";
+        exitNumber = "999";
     }
 
     
@@ -59,7 +65,7 @@ public class Stepdefs {
      
 
     public void otsikkoSyotetaan(String otsikko) throws IOException {
-        when(mockIO.readInput("\nValitse vinkki numerolla tai kirjoita teksti hakua varten:")).thenReturn("0", "99");
+        when(mockIO.readInput("\nValitse vinkki numerolla tai kirjoita teksti hakua varten:")).thenReturn(addNumber, exitNumber);
         when(mockIO.readInput("\nAnna lukuvinkin otsikko: ")).thenReturn(otsikko);
         
         ui.run();

--- a/src/test/java/dao/LukuvinkkiDaoTest.java
+++ b/src/test/java/dao/LukuvinkkiDaoTest.java
@@ -5,9 +5,12 @@ import domain.Lukuvinkki;
 import dao.LukuvinkkiDao;
 
 import java.io.FileNotFoundException;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.After;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.Before;
@@ -22,14 +25,21 @@ public class LukuvinkkiDaoTest {
     @Before
     public void setUp() throws IOException, FileNotFoundException {
 
-        l = new Kirja("Moby Dick");
-        v = new Kirja("Huckleberry Finn");
+        l = new Lukuvinkki("Moby Dick");
+        v = new Lukuvinkki("Huckleberry Finn");
         vinkkeja = new ArrayList<Lukuvinkki>();
         vinkkeja.add(l);
         vinkkeja.add(v);
         dao = new LukuvinkkiDao();
         dao.useTestFile();
 
+    }
+    
+    // tyhjennet‰‰n file jokaisen testin j‰lkeen
+    @After
+    public void tearDown() throws FileNotFoundException, IOException {
+        FileWriter pw = new FileWriter("./Test.txt");
+        pw.close();
     }
 
     @Test
@@ -42,6 +52,7 @@ public class LukuvinkkiDaoTest {
         int koko = haetutVin.size() - 1;
 
         assertEquals(l.getLabel(), haetutVin.get(koko).getLabel());
+        assertEquals(1, haetutVin.size());
     }
 
     @Test
@@ -49,11 +60,13 @@ public class LukuvinkkiDaoTest {
         
         dao.saveToFile(l);
         dao.saveToFile(v);
+        
         List<Lukuvinkki> haetutVin = dao.readFromFile();
 
         int koko = haetutVin.size() - 1;
 
         assertEquals(v.getLabel(), haetutVin.get(koko).getLabel());
+        assertEquals(2, haetutVin.size());
     }
 
     @Test
@@ -62,7 +75,33 @@ public class LukuvinkkiDaoTest {
         dao.saveListToFile(vinkkeja);
 
         assertEquals(l.getLabel(), dao.readFromFile().get(0).getLabel());
-
     }
-
+    
+    @Test
+    public void poistoToimiiKunPoistetaanAinoaVinkki() throws IOException, FileNotFoundException {
+        
+        dao.saveToFile(l);
+        
+        dao.deleteFromFile(l);
+        
+        List<Lukuvinkki> haetutVin = dao.readFromFile();
+        
+        assertEquals(0, haetutVin.size());
+        
+    }
+    
+    @Test
+    public void poistoToimiiKunJaljelleJaaYksiVinkki() throws IOException, FileNotFoundException {
+        
+        dao.saveToFile(l);
+        dao.saveToFile(v);
+        
+        dao.deleteFromFile(v);
+        
+        List<Lukuvinkki> haetutVin = dao.readFromFile();
+        
+        assertEquals(1, haetutVin.size());
+        
+    }
+    
 }

--- a/src/test/java/ui/ConsoleUITest.java
+++ b/src/test/java/ui/ConsoleUITest.java
@@ -18,7 +18,10 @@ public class ConsoleUITest {
     ConsoleIO console;
     LukuvinkkiDao dao;
     ConsoleUI ui;
-
+    
+    String addNumber;
+    String exitNumber;
+    
     @Before
     public void setUp() {
         console = mock(ConsoleIO.class);
@@ -26,11 +29,14 @@ public class ConsoleUITest {
         ui = new ConsoleUI(console, dao);
         vinkit.add(new Kirja("Koraani"));
         vinkit.add(new Kirja("Pieni punainen kirja"));
+        
+        addNumber = "0";
+        exitNumber = "999";
     }
     
     @Test(timeout = 1000) public void uiKysyyToiminnon() throws IOException, FileNotFoundException {
      
-        when(console.readInput("\nValitse vinkki numerolla tai kirjoita teksti hakua varten:")).thenReturn("99");
+        when(console.readInput("\nValitse vinkki numerolla tai kirjoita teksti hakua varten:")).thenReturn(exitNumber);
         
         ui.run(); 
         
@@ -40,7 +46,7 @@ public class ConsoleUITest {
     @Test(timeout = 1000) public void uiTallentaaVinkin() throws IOException {
         try { when(dao.readFromFile()).thenReturn(vinkit); } catch (Exception e) { }
         when(console.readInput("\nValitse vinkki numerolla tai kirjoita teksti hakua varten:")).
-        thenReturn("0", "99");
+        thenReturn(addNumber, exitNumber);
         
         when(console.readInput("\nAnna lukuvinkin otsikko: ")).thenReturn("Raamattu");
         ui.run(); 
@@ -53,7 +59,7 @@ public class ConsoleUITest {
         try { when(dao.readFromFile()).thenReturn(vinkit); 
         } catch (Exception e) { 
         } 
-        when(console.readInput("\nValitse vinkki numerolla tai kirjoita teksti hakua varten:")).thenReturn("0", "99");
+        when(console.readInput("\nValitse vinkki numerolla tai kirjoita teksti hakua varten:")).thenReturn(addNumber, exitNumber);
         
         when(console.readInput("\nAnna lukuvinkin otsikko: ")).thenReturn("Raamattu");
         ui.run(); 


### PR DESCRIPTION
Lisätty mahdollisuus vinkin poistoon. Toteutin poiston samalla käyttöliittymään, koska testaaminen oli näin paljon helpompaa. Poisto toimii samalla tavalla kuin linkin lisäys vinkille, eli vinkki valitaan id:llä listasta ja siitä valitaan linkin lisäys/poisto.

Refaktoroin jonkun verran LukuvinkkiDao:ta, lähinnä poistin copypastea ja lisäsin try-catcheja. LukuvinkkiDao:n testeissä oli ongelmia ja syyksi paljastui, ettei testitiedostoa tyhjennetä yksittäisten testien välissä - tämä nyt korjattu.